### PR TITLE
changes video to true so that liveslide embeds will show

### DIFF
--- a/_layouts/paper.html
+++ b/_layouts/paper.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-video: false
+video: true
 chat: true
 session_1: false
 session_2: false


### PR DESCRIPTION
Some attendees have pointed out in the ICLR rocket chat that the slidelive videos are not displaying for papers on https://baicsworkshop.github.io/papers.html.  Changing video to true triggers the logic to add the slidlive embeds into the pages for papers.  I am not sure if this has unintended consequences.